### PR TITLE
Fix `--send` argument parsing

### DIFF
--- a/matrix.sh
+++ b/matrix.sh
@@ -331,7 +331,7 @@ for i in "$@"; do
 			ACTION="invite_user"
 			shift
 			;;
-		--send-message|send)
+		--send-message|--send)
 			ACTION="send"
 			shift
 			;;


### PR DESCRIPTION
The doc state that `--send` can be used to send a message, but the
parser expected `send` instead.