### PR TITLE
Add "file" and "coreutils" to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ wrapped in &lt;pre&gt; tags.
 * Install dependencies:
     * `curl`
     * `jq`
+    * `file`
+    * `coreutils` (required for `du -b`)
 
     Something like `sudo apt-get install curl jq`.
 * Use it to log in. See Usage.


### PR DESCRIPTION
Adds a couple of required packages missing in e.g. `library/alpine` Docker images.

```
/ # cat /etc/alpine-release 
3.14.2
/ # which file; echo $?
1
/ # which coreutils; echo $?; du -b
1
du: unrecognized option: b
BusyBox v1.33.1 () multi-call binary.

Usage: du [-aHLdclsxhmk] [FILE]...
```